### PR TITLE
fix errors with nifi 2.0.0-M2 around the removal of the variable regi…

### DIFF
--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/BasePlc4xProcessor.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/BasePlc4xProcessor.java
@@ -102,7 +102,7 @@ public abstract class BasePlc4xProcessor extends AbstractProcessor {
 		.description("Maximum number of entries in the cache. Can improve performance when addresses change dynamically.")
 		.defaultValue("1")
 		.required(true)
-        .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+        .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
 		.addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
 		.build();
 
@@ -121,7 +121,7 @@ public abstract class BasePlc4xProcessor extends AbstractProcessor {
         .displayName("Timestamp Field Name")
         .description("Name of the field that will display the timestamp of the operation.")
         .required(true)
-        .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+        .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
         .addValidator(new Plc4xTimestampFieldValidator())
         .defaultValue("ts")
         .build();

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/Plc4xSourceProcessorTest.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/Plc4xSourceProcessorTest.java
@@ -42,7 +42,7 @@ public class Plc4xSourceProcessorTest {
         testRunner.setIncomingConnection(false);
         testRunner.setValidateExpressionUsage(true);
 
-        testRunner.setVariable("url", "simulated://127.0.0.1");
+        testRunner.setEnvironmentVariableValue("url", "simulated://127.0.0.1");
         testRunner.setProperty(Plc4xSourceProcessor.PLC_CONNECTION_STRING, "${url}");
         testRunner.setProperty(Plc4xSourceProcessor.PLC_FUTURE_TIMEOUT_MILISECONDS, "1000");
 

--- a/plc4j/integrations/apache-nifi/pom.xml
+++ b/plc4j/integrations/apache-nifi/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <project.build.outputTimestamp>2024-02-16T14:53:02Z</project.build.outputTimestamp>
-        <nifi.version>1.25.0</nifi.version>
+        <nifi.version>2.0.0-M2</nifi.version>
         <avro.version>1.11.3</avro.version>
     </properties>
 


### PR DESCRIPTION
…stry and the replacment with environmentvariable

this would mean release 13 would only support nifi 2.0.0-M2+