### PR TITLE
fix address dynamic properties not deleting in nifi processors

### DIFF
--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/BasePlc4xProcessor.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/BasePlc4xProcessor.java
@@ -194,7 +194,6 @@ public abstract class BasePlc4xProcessor extends AbstractProcessor {
                 .name(propertyDescriptorName)
                 .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
                 .addValidator(StandardValidators.ATTRIBUTE_KEY_PROPERTY_NAME_VALIDATOR)
-                .dependsOn(AddressesAccessUtils.PLC_ADDRESS_ACCESS_STRATEGY, AddressesAccessUtils.ADDRESS_PROPERTY)
                 .addValidator(new DynamicPropertyAccessStrategy.TagValidator(AddressesAccessUtils.getManager()))
                 .required(false)
                 .dynamic(true)


### PR DESCRIPTION
This PR addresses an issue in the NiFi processors where dynamic properties do not delete when "Address Access Strategy" is set to "Use Properties as Addresses". In fact, clicking "Delete" causes a property to visually disappear, but reappears upon re-entering the processor. This behavior is resolved by removing the `.dependsOn()` line from the dynamic properties.