### PR TITLE
Fix get array on source processor to not overwrite values

### DIFF
--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/BasePlc4xProcessor.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/BasePlc4xProcessor.java
@@ -315,9 +315,18 @@ public abstract class BasePlc4xProcessor extends AbstractProcessor {
    protected void evaluateReadResponse(final ProcessSession session, final FlowFile flowFile, final PlcReadResponse response) {
         Map<String, String> attributes = new HashMap<>();
         for (String tagName : response.getTagNames()) {
-            for (int i = 0; i < response.getNumberOfValues(tagName); i++) {
-                Object value = response.getObject(tagName, i);
+            
+            // Write single value tag-response on "tagName" attribute
+            if (response.getNumberOfValues(tagName) == 1) {
+                Object value = response.getObject(tagName, 0);
                 attributes.put(tagName, String.valueOf(value));
+            
+            // Write multi-value tag-response on "tagName_i" attribute
+            } else {
+                for (int i = 0; i < response.getNumberOfValues(tagName); i++) {
+                    Object value = response.getObject(tagName, i);
+                    attributes.put(tagName + "_" + i, String.valueOf(value));
+                }
             }
         }
         session.putAllAttributes(flowFile, attributes);


### PR DESCRIPTION
Possible fix for the closed issue https://github.com/apache/plc4x-extras/issues/332
When reading an array on the Plc4xSourceProcessor only the last value of the array is written on the FlowFile attributes

This processor may be deprecated soon, there is a PR by @ottobackwards: https://github.com/apache/plc4x-extras/pull/333

Until it is completely removed from the plc4x-extras repo, on the next release, maybe we could "solve it"?