### PR TITLE
NiFi Integration - Fix array reading

### DIFF
--- a/plc4j/integrations/apache-nifi/nifi-1/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/util/Plc4xCommon.java
+++ b/plc4j/integrations/apache-nifi/nifi-1/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/util/Plc4xCommon.java
@@ -80,6 +80,15 @@ public class Plc4xCommon {
 	private static DataType getDataType(final Object valueOriginal) {
 
 		PlcValue value = (PlcValue) valueOriginal;
+
+		// Lists. Inner data type default to STRING if empty list
+		if (value instanceof PlcList && value.isList()){
+			if (!value.getList().isEmpty()) {
+				return RecordFieldType.ARRAY.getArrayDataType(getDataType(value.getList().get(0))); 
+			}
+			return RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.STRING.getDataType());
+		}
+
 		// 8 bits
 		if (value instanceof PlcBOOL && value.isBoolean())
 			return RecordFieldType.BOOLEAN.getDataType();

--- a/plc4j/integrations/apache-nifi/nifi-1/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/util/Plc4xCommonTest.java
+++ b/plc4j/integrations/apache-nifi/nifi-1/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/util/Plc4xCommonTest.java
@@ -61,7 +61,7 @@ public class Plc4xCommonTest {
         // recordFields.add(new RecordField("WORD", "4")    String
         recordFields.add(new RecordField("SINT", RecordFieldType.SHORT.getDataType(), -5));
         recordFields.add(new RecordField("USINT", RecordFieldType.SHORT.getDataType(), "6"));
-        recordFields.add(new RecordField("INT", RecordFieldType.INT.getDataType(), 2000));
+        recordFields.add(new RecordField("INT", RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.INT.getDataType())));
         recordFields.add(new RecordField("UINT", RecordFieldType.INT.getDataType(), "3000"));
         recordFields.add(new RecordField("DINT", RecordFieldType.INT.getDataType(), "4000"));
         recordFields.add(new RecordField("UDINT", RecordFieldType.LONG.getDataType(), "5000"));
@@ -84,7 +84,7 @@ public class Plc4xCommonTest {
         originalMap.put("WORD", "4");
         originalMap.put("SINT", -5);
         originalMap.put("USINT", "6");
-        originalMap.put("INT", 2000);
+        originalMap.put("INT", new int[]{2000, 3000, 4000, 5000});
         originalMap.put("UINT", "3000");
         originalMap.put("DINT", "4000");
         originalMap.put("UDINT", "5000");
@@ -103,7 +103,7 @@ public class Plc4xCommonTest {
         addressMap.put("WORD", "RANDOM/v3:WORD");
         addressMap.put("SINT", "RANDOM/v4:SINT");
         addressMap.put("USINT", "RANDOM/v5:USINT");
-        addressMap.put("INT", "RANDOM/v6:INT");
+        addressMap.put("INT", "RANDOM/v6:INT[4]");
         addressMap.put("UINT", "RANDOM/v7:UINT");
         addressMap.put("DINT", "RANDOM/v8:DINT");
         addressMap.put("UDINT", "RANDOM/v9:UDINT");
@@ -175,8 +175,17 @@ public class Plc4xCommonTest {
     
                                 // Check type
                                 if (checkType) {
-                                    logger.info("{} Checking type: {} ({}) =? {}", tag, value.getClass(), value, Plc4xCommonTest.typeMap.get(tag));
-                                    assert value.getClass().equals(Plc4xCommonTest.typeMap.get(tag));
+                                    if (!(value instanceof Object[])) {
+                                        logger.info("{} Checking type: {} ({}) =? {}", tag, value.getClass(), value,
+                                                Plc4xCommonTest.typeMap.get(tag));
+                                        assert value.getClass().equals(Plc4xCommonTest.typeMap.get(tag));
+                                    } else {
+                                        logger.info("{} Checking List type: {} ({}) =? {}", tag,
+                                                ((Object[]) value)[0].getClass(), value,
+                                                Plc4xCommonTest.typeMap.get(tag));
+                                        assert ((Object[]) value)[0].getClass()
+                                                .equals(Plc4xCommonTest.typeMap.get(tag));
+                                    }
                                 }
                             }
                         }

--- a/plc4j/integrations/apache-nifi/nifi-2/nifi-2-plc4x-processors/src/main/java/org/apache/plc4x/nifi/util/Plc4xCommon.java
+++ b/plc4j/integrations/apache-nifi/nifi-2/nifi-2-plc4x-processors/src/main/java/org/apache/plc4x/nifi/util/Plc4xCommon.java
@@ -80,6 +80,15 @@ public class Plc4xCommon {
 	private static DataType getDataType(final Object valueOriginal) {
 
 		PlcValue value = (PlcValue) valueOriginal;
+
+		// Lists. Inner data type default to STRING if empty list
+		if (value instanceof PlcList && value.isList()){
+			if (!value.getList().isEmpty()) {
+				return RecordFieldType.ARRAY.getArrayDataType(getDataType(value.getList().get(0))); 
+			}
+			return RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.STRING.getDataType());
+		}
+
 		// 8 bits
 		if (value instanceof PlcBOOL && value.isBoolean())
 			return RecordFieldType.BOOLEAN.getDataType();

--- a/plc4j/integrations/apache-nifi/nifi-2/nifi-2-plc4x-processors/src/test/java/org/apache/plc4x/nifi/util/Plc4xCommonTest.java
+++ b/plc4j/integrations/apache-nifi/nifi-2/nifi-2-plc4x-processors/src/test/java/org/apache/plc4x/nifi/util/Plc4xCommonTest.java
@@ -62,7 +62,7 @@ public class Plc4xCommonTest {
         // recordFields.add(new RecordField("WORD", "4")    String
         recordFields.add(new RecordField("SINT", RecordFieldType.SHORT.getDataType(), -5));
         recordFields.add(new RecordField("USINT", RecordFieldType.SHORT.getDataType(), "6"));
-        recordFields.add(new RecordField("INT", RecordFieldType.INT.getDataType(), 2000));
+        recordFields.add(new RecordField("INT", RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.INT.getDataType())));
         recordFields.add(new RecordField("UINT", RecordFieldType.INT.getDataType(), "3000"));
         recordFields.add(new RecordField("DINT", RecordFieldType.INT.getDataType(), "4000"));
         recordFields.add(new RecordField("UDINT", RecordFieldType.LONG.getDataType(), "5000"));
@@ -85,7 +85,7 @@ public class Plc4xCommonTest {
         originalMap.put("WORD", "4");
         originalMap.put("SINT", -5);
         originalMap.put("USINT", "6");
-        originalMap.put("INT", 2000);
+        originalMap.put("INT", new int[]{2000, 3000, 4000, 5000});
         originalMap.put("UINT", "3000");
         originalMap.put("DINT", "4000");
         originalMap.put("UDINT", "5000");
@@ -104,7 +104,7 @@ public class Plc4xCommonTest {
         addressMap.put("WORD", "RANDOM/v3:WORD");
         addressMap.put("SINT", "RANDOM/v4:SINT");
         addressMap.put("USINT", "RANDOM/v5:USINT");
-        addressMap.put("INT", "RANDOM/v6:INT");
+        addressMap.put("INT", "RANDOM/v6:INT[4]");
         addressMap.put("UINT", "RANDOM/v7:UINT");
         addressMap.put("DINT", "RANDOM/v8:DINT");
         addressMap.put("UDINT", "RANDOM/v9:UDINT");
@@ -176,8 +176,13 @@ public class Plc4xCommonTest {
     
                                 // Check type
                                 if (checkType) {
-                                    logger.info("{} Checking type: {} ({}) =? {}", tag, value.getClass(), value, Plc4xCommonTest.typeMap.get(tag));
-                                    assert value.getClass().equals(Plc4xCommonTest.typeMap.get(tag));
+                                    if (!(value instanceof Object[])) {
+                                        logger.info("{} Checking type: {} ({}) =? {}", tag, value.getClass(), value, Plc4xCommonTest.typeMap.get(tag));
+                                        assert value.getClass().equals(Plc4xCommonTest.typeMap.get(tag));
+                                    } else {
+                                        logger.info("{} Checking List type: {} ({}) =? {}", tag, ((Object[]) value)[0].getClass(), value, Plc4xCommonTest.typeMap.get(tag));
+                                        assert ((Object[]) value)[0].getClass().equals(Plc4xCommonTest.typeMap.get(tag));
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Related issue: https://github.com/apache/plc4x-extras/issues/337

Reading arrays on NiFi integration such as:
```
holding-register:1:INT[2] 
```
Resulted on results on `"mock/modbus/Q" : "[Ljava.lang.Object;@5293cbff"`  (Expected: `"mock/modbus/Q": [0,1]`)

On `Plc4xCommon#getDataType` there was not a check for PlcList type, defaulting on String record type instead of Array.
Added check for PlcList type and modified unit tests to test array reading and writting.

Also tested writing arrays from NiFi and it does work, at least on modbus.